### PR TITLE
Conflict probing improvements

### DIFF
--- a/AtopPlugin.cs
+++ b/AtopPlugin.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel.Composition;
+using System.Windows.Forms;
 using AtopPlugin.Display;
 using AtopPlugin.State;
+using AtopPlugin.UI;
 using vatsys;
 using vatsys.Plugin;
 
@@ -11,9 +13,17 @@ public class AtopPlugin : ILabelPlugin, IStripPlugin
 {
     public string Name => "ATOP Plugin";
 
+    private static readonly SettingsWindow SettingsWindow;
+
+    static AtopPlugin()
+    {
+        SettingsWindow = new SettingsWindow();
+    }
+
     public AtopPlugin()
     {
         RegisterEventHandlers();
+        AddCustomMenuItems();
     }
 
     private static void RegisterEventHandlers()
@@ -24,6 +34,17 @@ public class AtopPlugin : ILabelPlugin, IStripPlugin
         // changes to cleared flight level do not register an FDR update
         // we need to create custom handlers to be able to update the label/strip
         FdrPropertyChangesListener.RegisterAllHandlers();
+    }
+
+    private static void AddCustomMenuItems()
+    {
+        var settingsMenu = new CustomToolStripMenuItem(CustomToolStripMenuItemWindowType.Main,
+            CustomToolStripMenuItemCategory.Custom, new ToolStripMenuItem("Settings"))
+        {
+            CustomCategoryName = "ATOP"
+        };
+        settingsMenu.Item.Click += (_, _) => MMI.InvokeOnGUI(SettingsWindow.Show);
+        MMI.AddCustomMenuItem(settingsMenu);
     }
 
     public void OnFDRUpdate(FDP2.FDR updated)

--- a/AtopPlugin.cs
+++ b/AtopPlugin.cs
@@ -30,6 +30,7 @@ public class AtopPlugin : ILabelPlugin, IStripPlugin
     {
         AtopPluginStateManager.ProcessFdrUpdate(updated);
         AtopPluginStateManager.ProcessDisplayUpdate(updated);
+        AtopPluginStateManager.RunConflictProbe(updated);
         FdrPropertyChangesListener.RegisterHandler(updated);
 
         // don't manage jurisdiction if not connected as ATC

--- a/AtopPlugin.csproj
+++ b/AtopPlugin.csproj
@@ -38,6 +38,10 @@
         <Reference Include="System"/>
         <Reference Include="System.ComponentModel.Composition"/>
         <Reference Include="System.Core"/>
+        <Reference Include="System.Drawing"/>
+        <Reference Include="System.Windows.Forms">
+            <HintPath>packages\Microsoft.NETFramework.ReferenceAssemblies.net48.1.0.3\build\.NETFramework\v4.8\System.Windows.Forms.dll</HintPath>
+        </Reference>
         <Reference Include="System.Xml.Linq"/>
         <Reference Include="System.Data.DataSetExtensions"/>
         <Reference Include="Microsoft.CSharp"/>
@@ -79,6 +83,27 @@
         <Compile Include="State\JurisdictionManager.cs"/>
         <Compile Include="State\PrivateMessagesChangedHandler.cs"/>
         <Compile Include="State\RadarFlagToggleHandler.cs"/>
+        <Compile Include="UI\SettingsWindow.cs">
+            <SubType>Form</SubType>
+        </Compile>
+        <Compile Include="UI\SettingsWindow.Designer.cs">
+            <DependentUpon>SettingsWindow.cs</DependentUpon>
+        </Compile>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="packages.config"/>
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="UI\SettingsWindow.resx">
+            <DependentUpon>SettingsWindow.cs</DependentUpon>
+        </EmbeddedResource>
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+    <Import Project="packages\Microsoft.NETFramework.ReferenceAssemblies.net48.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net48.targets" Condition="Exists('packages\Microsoft.NETFramework.ReferenceAssemblies.net48.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net48.targets')"/>
+    <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+        <PropertyGroup>
+            <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+        </PropertyGroup>
+        <Error Condition="!Exists('packages\Microsoft.NETFramework.ReferenceAssemblies.net48.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net48.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.NETFramework.ReferenceAssemblies.net48.1.0.3\build\Microsoft.NETFramework.ReferenceAssemblies.net48.targets'))"/>
+    </Target>
 </Project>

--- a/Display/TrackColorRenderer.cs
+++ b/Display/TrackColorRenderer.cs
@@ -32,7 +32,7 @@ public static class TrackColorRenderer
 
     private static CustomColour? GetConflictColour(FDP2.FDR fdr)
     {
-        return fdr.GetAtopState()?.Conflicts switch
+        return fdr.GetConflicts() switch
         {
             { ActualConflicts.Count: > 0 } or { ImminentConflicts.Count: > 0 } => CustomColors.Imminent,
             { AdvisoryConflicts.Count: > 0 } => CustomColors.Advisory,

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using AtopPlugin.State;
+﻿using AtopPlugin.Conflict;
+using AtopPlugin.State;
 using vatsys;
 
 namespace AtopPlugin;
@@ -13,6 +14,11 @@ public static class Extensions
     public static AtopAircraftDisplayState? GetDisplayState(this FDP2.FDR fdr)
     {
         return AtopPluginStateManager.GetDisplayState(fdr.Callsign);
+    }
+
+    public static ConflictProbe.Conflicts? GetConflicts(this FDP2.FDR fdr)
+    {
+        return AtopPluginStateManager.GetConflicts(fdr.Callsign);
     }
 
     public static int? GetTransponderCode(this FDP2.FDR fdr)

--- a/State/AtopAircraftState.cs
+++ b/State/AtopAircraftState.cs
@@ -1,5 +1,4 @@
-﻿using AtopPlugin.Conflict;
-using AtopPlugin.Logic;
+﻿using AtopPlugin.Logic;
 using AtopPlugin.Models;
 using vatsys;
 
@@ -17,7 +16,6 @@ public class AtopAircraftState
     }
 
     public FDP2.FDR Fdr { get; private set; }
-    public ConflictProbe.Conflicts Conflicts { get; private set; }
     public CalculatedFlightData CalculatedFlightData { get; private set; }
     public DirectionOfFlight DirectionOfFlight { get; private set; }
     public SccFlag? HighestSccFlag { get; private set; }
@@ -33,7 +31,6 @@ public class AtopAircraftState
     public void UpdateFromFdr(FDP2.FDR updatedFdr)
     {
         Fdr = updatedFdr;
-        Conflicts = ConflictProbe.Probe(updatedFdr);
 
         CalculatedFlightData = FlightDataCalculator.GetCalculatedFlightData(updatedFdr);
         DirectionOfFlight = DirectionOfFlightCalculator.GetDirectionOfFlight(updatedFdr);

--- a/State/AtopPluginStateManager.cs
+++ b/State/AtopPluginStateManager.cs
@@ -12,6 +12,7 @@ public static class AtopPluginStateManager
     private static readonly ConcurrentDictionary<string, AtopAircraftState> AircraftStates = new();
     private static readonly ConcurrentDictionary<string, AtopAircraftDisplayState> DisplayStates = new();
     private static readonly ConcurrentDictionary<string, ConflictProbe.Conflicts> Conflicts = new();
+    private static bool _probeEnabled = true;
 
     public static AtopAircraftState? GetAircraftState(string callsign)
     {
@@ -74,8 +75,22 @@ public static class AtopPluginStateManager
 
     public static async Task RunConflictProbe(FDP2.FDR fdr)
     {
-        var newConflicts = await Task.Run(() => ConflictProbe.Probe(fdr));
-        Conflicts.AddOrUpdate(fdr.Callsign, newConflicts, (_, _) => newConflicts);
+        if (_probeEnabled)
+        {
+            var newConflicts = await Task.Run(() => ConflictProbe.Probe(fdr));
+            Conflicts.AddOrUpdate(fdr.Callsign, newConflicts, (_, _) => newConflicts);
+        }
+    }
+
+    public static bool IsConflictProbeEnabled()
+    {
+        return _probeEnabled;
+    }
+
+    public static void SetConflictProbe(bool conflictProbeEnabled)
+    {
+        _probeEnabled = conflictProbeEnabled;
+        if (!_probeEnabled) Conflicts.Clear();
     }
 
     public static void Reset()

--- a/State/FdrPropertyChangesListener.cs
+++ b/State/FdrPropertyChangesListener.cs
@@ -29,5 +29,6 @@ public static class FdrPropertyChangesListener
         if (!RelevantProperties.Contains(eventArgs.PropertyName)) return;
         await AtopPluginStateManager.ProcessFdrUpdate(fdr);
         await AtopPluginStateManager.ProcessDisplayUpdate(fdr);
+        await AtopPluginStateManager.RunConflictProbe(fdr);
     }
 }

--- a/UI/SettingsWindow.Designer.cs
+++ b/UI/SettingsWindow.Designer.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+
+namespace AtopPlugin.UI;
+
+partial class SettingsWindow
+{
+    /// <summary>
+    /// Required designer variable.
+    /// </summary>
+    private IContainer components = null;
+
+    /// <summary>
+    /// Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    /// Required method for Designer support - do not modify
+    /// the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        this.probe = new System.Windows.Forms.CheckBox();
+        this.SuspendLayout();
+        // 
+        // probe
+        // 
+        this.probe.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+        this.probe.Appearance = System.Windows.Forms.Appearance.Button;
+        this.probe.CheckAlign = System.Drawing.ContentAlignment.MiddleCenter;
+        this.probe.Font = new System.Drawing.Font("Terminus (TTF)", 18F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+        this.probe.Location = new System.Drawing.Point(25, 12);
+        this.probe.Name = "probe";
+        this.probe.Size = new System.Drawing.Size(100, 50);
+        this.probe.TabIndex = 1;
+        this.probe.Text = "PROBE";
+        this.probe.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+        this.probe.UseVisualStyleBackColor = true;
+        this.probe.CheckedChanged += new System.EventHandler(this.probe_CheckedChanged);
+        // 
+        // SettingsWindow
+        // 
+        this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 17F);
+        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+        this.ClientSize = new System.Drawing.Size(146, 72);
+        this.Controls.Add(this.probe);
+        this.Name = "SettingsWindow";
+        this.Text = "ATOP Settings";
+        this.TopMost = true;
+        this.ResumeLayout(false);
+    }
+
+    private System.Windows.Forms.CheckBox probe;
+
+    #endregion
+}

--- a/UI/SettingsWindow.cs
+++ b/UI/SettingsWindow.cs
@@ -1,0 +1,19 @@
+using System;
+using AtopPlugin.State;
+using vatsys;
+
+namespace AtopPlugin.UI;
+
+public partial class SettingsWindow : BaseForm
+{
+    public SettingsWindow()
+    {
+        InitializeComponent();
+        probe.Checked = AtopPluginStateManager.IsConflictProbeEnabled();
+    }
+
+    private void probe_CheckedChanged(object sender, EventArgs e)
+    {
+        AtopPluginStateManager.SetConflictProbe(probe.Checked);
+    }
+}

--- a/UI/SettingsWindow.resx
+++ b/UI/SettingsWindow.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.NETFramework.ReferenceAssemblies.net48" version="1.0.3" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.Spatial" version="7.17.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
- Decouple conflict probe from data block state updates
- Add settings window to enable/disable conflict probing for debugging (temporary until we get stuff cleaned up/correct)