### PR TITLE
Datablock bugfixes

### DIFF
--- a/Display/LabelItemRenderer.cs
+++ b/Display/LabelItemRenderer.cs
@@ -79,14 +79,14 @@ public static class LabelItemRenderer
             LabelConstants.LabelItemLevel => displayState.AltitudeColor == null
                 ? new CustomLabelItem
                 {
-                    Text = displayState.CurrentLevel,
+                    Text = displayState.CurrentLevel.PadLeft(3),
                     Border = displayState.AltitudeBorderFlags,
                     BorderColourIdentity = Colours.Identities.Custom,
                     CustomBorderColour = CustomColors.NotCda
                 }
                 : new CustomLabelItem
                 {
-                    Text = displayState.CurrentLevel,
+                    Text = displayState.CurrentLevel.PadLeft(3),
                     Border = displayState.AltitudeBorderFlags,
                     BorderColourIdentity = Colours.Identities.Custom,
                     CustomBorderColour = CustomColors.NotCda,
@@ -97,14 +97,14 @@ public static class LabelItemRenderer
             LabelConstants.LabelItemVmi => displayState.AltitudeColor == null
                 ? new CustomLabelItem
                 {
-                    Text = atopState.AltitudeFlag?.Value ?? "",
+                    Text = (atopState.AltitudeFlag?.Value ?? "").PadLeft(1),
                     Border = displayState.AltitudeBorderFlags,
                     BorderColourIdentity = Colours.Identities.Custom,
                     CustomBorderColour = CustomColors.NotCda
                 }
                 : new CustomLabelItem
                 {
-                    Text = atopState.AltitudeFlag?.Value ?? "",
+                    Text = (atopState.AltitudeFlag?.Value ?? "").PadLeft(1),
                     Border = displayState.AltitudeBorderFlags,
                     BorderColourIdentity = Colours.Identities.Custom,
                     CustomBorderColour = CustomColors.NotCda,
@@ -115,14 +115,14 @@ public static class LabelItemRenderer
             LabelConstants.LabelItemClearedLevel => displayState.AltitudeColor == null
                 ? new CustomLabelItem
                 {
-                    Text = displayState.ClearedLevel,
+                    Text = displayState.ClearedLevel.PadLeft(3),
                     Border = displayState.AltitudeBorderFlags,
                     BorderColourIdentity = Colours.Identities.Custom,
                     CustomBorderColour = CustomColors.NotCda
                 }
                 : new CustomLabelItem
                 {
-                    Text = displayState.ClearedLevel,
+                    Text = displayState.ClearedLevel.PadLeft(3),
                     Border = displayState.AltitudeBorderFlags,
                     BorderColourIdentity = Colours.Identities.Custom,
                     CustomBorderColour = CustomColors.NotCda,

--- a/Logic/SccFlagCalculator.cs
+++ b/Logic/SccFlagCalculator.cs
@@ -12,18 +12,12 @@ public static class SccFlagCalculator
     public static SccFlag? CalculateHighestPriorityFlag(FDP2.FDR fdr, CalculatedFlightData calculatedFlightData)
     {
         var transponderCode = fdr.GetTransponderCode();
-        switch (transponderCode)
+        return transponderCode switch
         {
-            case EmergencyCode:
-                return SccFlag.Emg;
-            case RadioFailureCode:
-                return SccFlag.Rcf;
-            case MilitaryInterceptCode:
-                return SccFlag.Mti;
-        }
-
-        if (!calculatedFlightData.Rnp4 || !calculatedFlightData.Rnp10) return SccFlag.Rnp;
-
-        return null;
+            EmergencyCode => SccFlag.Emg,
+            RadioFailureCode => SccFlag.Rcf,
+            MilitaryInterceptCode => SccFlag.Mti,
+            _ => calculatedFlightData is { Rnp4: false, Rnp10: false } ? SccFlag.Rnp : null
+        };
     }
 }

--- a/State/AtopAircraftDisplayState.cs
+++ b/State/AtopAircraftDisplayState.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using AtopPlugin.Logic;
 using AtopPlugin.Models;
 using vatsys;
@@ -86,7 +87,13 @@ public class AtopAircraftDisplayState
 
     private static string GetCurrentLevel(AtopAircraftState atopAircraftState)
     {
-        var prlHundreds = atopAircraftState.Fdr.PRL / 100;
+        var fdr = atopAircraftState.Fdr;
+        var altitudeBlock = AltitudeBlock.ExtractAltitudeBlock(fdr);
+
+        var prlHundreds = (int)Math.Round(atopAircraftState.Fdr.PRL / 100.0);
+        if (!atopAircraftState.PendingAltitudeChange || AltitudeCalculator.IsWithinThreshold(fdr.PRL, altitudeBlock))
+            return prlHundreds == 0 ? "" : (int)Math.Round(prlHundreds / 10.0) + "0";
+
         return prlHundreds == 0 ? "" : prlHundreds.ToString();
     }
 


### PR DESCRIPTION
- Add padding to show CFL offset when there is not a PRL
- Fix RNP SCC flag showing when aircraft was RNP10 equipped
- Show PRL rounded to flight level when within tolerance of CFL