### PR TITLE
Improve jurisdiction logic & add activation functionality

### DIFF
--- a/AtopPlugin.cs
+++ b/AtopPlugin.cs
@@ -43,8 +43,19 @@ public class AtopPlugin : ILabelPlugin, IStripPlugin
         {
             CustomCategoryName = "ATOP"
         };
+        var activationToggle = new ToolStripMenuItem("Activate");
+        var activationMenuItem = new CustomToolStripMenuItem(CustomToolStripMenuItemWindowType.Main,
+            CustomToolStripMenuItemCategory.Custom, activationToggle)
+        {
+            CustomCategoryName = "ATOP"
+        };
         settingsMenu.Item.Click += (_, _) => MMI.InvokeOnGUI(SettingsWindow.Show);
+        activationMenuItem.Item.Click += (_, _) => MMI.InvokeOnGUI(() =>
+        {
+            activationToggle.Checked = AtopPluginStateManager.SetActivated(!activationToggle.Checked);
+        });
         MMI.AddCustomMenuItem(settingsMenu);
+        MMI.AddCustomMenuItem(activationMenuItem);
     }
 
     public void OnFDRUpdate(FDP2.FDR updated)

--- a/AtopPlugin.cs
+++ b/AtopPlugin.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.Composition;
-using System.Windows.Forms;
 using AtopPlugin.Display;
 using AtopPlugin.State;
 using AtopPlugin.UI;
@@ -13,17 +12,10 @@ public class AtopPlugin : ILabelPlugin, IStripPlugin
 {
     public string Name => "ATOP Plugin";
 
-    private static readonly SettingsWindow SettingsWindow;
-
-    static AtopPlugin()
-    {
-        SettingsWindow = new SettingsWindow();
-    }
-
     public AtopPlugin()
     {
         RegisterEventHandlers();
-        AddCustomMenuItems();
+        AtopMenu.Initialize();
     }
 
     private static void RegisterEventHandlers()
@@ -34,28 +26,6 @@ public class AtopPlugin : ILabelPlugin, IStripPlugin
         // changes to cleared flight level do not register an FDR update
         // we need to create custom handlers to be able to update the label/strip
         FdrPropertyChangesListener.RegisterAllHandlers();
-    }
-
-    private static void AddCustomMenuItems()
-    {
-        var settingsMenu = new CustomToolStripMenuItem(CustomToolStripMenuItemWindowType.Main,
-            CustomToolStripMenuItemCategory.Custom, new ToolStripMenuItem("Settings"))
-        {
-            CustomCategoryName = "ATOP"
-        };
-        var activationToggle = new ToolStripMenuItem("Activate");
-        var activationMenuItem = new CustomToolStripMenuItem(CustomToolStripMenuItemWindowType.Main,
-            CustomToolStripMenuItemCategory.Custom, activationToggle)
-        {
-            CustomCategoryName = "ATOP"
-        };
-        settingsMenu.Item.Click += (_, _) => MMI.InvokeOnGUI(SettingsWindow.Show);
-        activationMenuItem.Item.Click += (_, _) => MMI.InvokeOnGUI(() =>
-        {
-            activationToggle.Checked = AtopPluginStateManager.SetActivated(!activationToggle.Checked);
-        });
-        MMI.AddCustomMenuItem(settingsMenu);
-        MMI.AddCustomMenuItem(activationMenuItem);
     }
 
     public void OnFDRUpdate(FDP2.FDR updated)

--- a/AtopPlugin.csproj
+++ b/AtopPlugin.csproj
@@ -83,6 +83,7 @@
         <Compile Include="State\JurisdictionManager.cs"/>
         <Compile Include="State\PrivateMessagesChangedHandler.cs"/>
         <Compile Include="State\RadarFlagToggleHandler.cs"/>
+        <Compile Include="UI\AtopMenu.cs"/>
         <Compile Include="UI\SettingsWindow.cs">
             <SubType>Form</SubType>
         </Compile>

--- a/State/AtopAircraftState.cs
+++ b/State/AtopAircraftState.cs
@@ -12,7 +12,7 @@ public class AtopAircraftState
         UpdateFromFdr(fdr);
         DownlinkIndicator = false;
         RadarToggleIndicator = false;
-        PreviouslyTracked = false;
+        WasHandedOff = false;
     }
 
     public FDP2.FDR Fdr { get; private set; }
@@ -23,7 +23,7 @@ public class AtopAircraftState
     public SectorsVolumes.Sector? NextSector { get; private set; }
     public bool DownlinkIndicator { get; set; }
     public bool RadarToggleIndicator { get; set; }
-    public bool PreviouslyTracked { get; set; }
+    public bool WasHandedOff { get; private set; }
     public bool PendingAltitudeChange { get; private set; }
 
     private AltitudeBlock PreviousAltitudeBlock { get; set; }
@@ -34,6 +34,7 @@ public class AtopAircraftState
 
         CalculatedFlightData = FlightDataCalculator.GetCalculatedFlightData(updatedFdr);
         DirectionOfFlight = DirectionOfFlightCalculator.GetDirectionOfFlight(updatedFdr);
+        WasHandedOff = !WasHandedOff && (updatedFdr.IsHandoff || updatedFdr.ControllingSector == null);
         HighestSccFlag = SccFlagCalculator.CalculateHighestPriorityFlag(updatedFdr, CalculatedFlightData);
 
         // ensure the bool for altitude change is calculated first since it is used in the altitude flag calculation

--- a/State/AtopPluginStateManager.cs
+++ b/State/AtopPluginStateManager.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using AtopPlugin.Conflict;
+using AtopPlugin.UI;
 using vatsys;
 
 namespace AtopPlugin.State;
@@ -15,6 +16,16 @@ public static class AtopPluginStateManager
     private static readonly ConcurrentDictionary<string, ConflictProbe.Conflicts> Conflicts = new();
     private static bool _probeEnabled = true;
     private static bool _activated = false;
+
+    public static bool Activated
+    {
+        get => _activated;
+        set
+        {
+            _activated = value;
+            AtopMenu.SetActivationState(value);
+        }
+    }
 
     public static AtopAircraftState? GetAircraftState(string callsign)
     {
@@ -95,18 +106,15 @@ public static class AtopPluginStateManager
         if (!_probeEnabled) Conflicts.Clear();
     }
 
-    public static bool IsActivated()
+    public static void ToggleActivated()
     {
-        return _activated;
-    }
+        var newActivationState = !Activated;
 
-    public static bool SetActivated(bool activated)
-    {
-        switch (activated)
+        switch (newActivationState)
         {
             case true when !Network.IsConnected:
                 MessageBox.Show(@"Please connect to the network before activating");
-                return false;
+                return;
             case true:
                 MessageBox.Show(@"Session activated");
                 break;
@@ -114,10 +122,8 @@ public static class AtopPluginStateManager
                 MessageBox.Show(@"Session deactivated");
                 break;
         }
-
-        _activated = activated;
-
-        return activated;
+        
+        Activated = newActivationState;
     }
 
     public static void Reset()
@@ -125,6 +131,6 @@ public static class AtopPluginStateManager
         AircraftStates.Clear();
         DisplayStates.Clear();
         Conflicts.Clear();
-        _activated = false;
+        Activated = false;
     }
 }

--- a/State/AtopPluginStateManager.cs
+++ b/State/AtopPluginStateManager.cs
@@ -116,6 +116,7 @@ public static class AtopPluginStateManager
         }
 
         _activated = activated;
+
         return activated;
     }
 

--- a/State/AtopPluginStateManager.cs
+++ b/State/AtopPluginStateManager.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 using AtopPlugin.Conflict;
 using vatsys;
 
@@ -13,6 +14,7 @@ public static class AtopPluginStateManager
     private static readonly ConcurrentDictionary<string, AtopAircraftDisplayState> DisplayStates = new();
     private static readonly ConcurrentDictionary<string, ConflictProbe.Conflicts> Conflicts = new();
     private static bool _probeEnabled = true;
+    private static bool _activated = false;
 
     public static AtopAircraftState? GetAircraftState(string callsign)
     {
@@ -93,10 +95,35 @@ public static class AtopPluginStateManager
         if (!_probeEnabled) Conflicts.Clear();
     }
 
+    public static bool IsActivated()
+    {
+        return _activated;
+    }
+
+    public static bool SetActivated(bool activated)
+    {
+        switch (activated)
+        {
+            case true when !Network.IsConnected:
+                MessageBox.Show(@"Please connect to the network before activating");
+                return false;
+            case true:
+                MessageBox.Show(@"Session activated");
+                break;
+            case false:
+                MessageBox.Show(@"Session deactivated");
+                break;
+        }
+
+        _activated = activated;
+        return activated;
+    }
+
     public static void Reset()
     {
         AircraftStates.Clear();
         DisplayStates.Clear();
         Conflicts.Clear();
+        _activated = false;
     }
 }

--- a/State/JurisdictionManager.cs
+++ b/State/JurisdictionManager.cs
@@ -15,11 +15,7 @@ public static class JurisdictionManager
         var atopState = fdr.GetAtopState();
 
         // check if aircraft previously tracked to avoid re-tracking manually dropped/handed off tracks
-        if (isInControlledSector && !fdr.IsTracked && atopState is { PreviouslyTracked: false })
-        {
-            MMI.AcceptJurisdiction(fdr);
-            atopState.PreviouslyTracked = true;
-        }
+        if (isInControlledSector && !fdr.IsTracked && atopState is { WasHandedOff: false }) MMI.AcceptJurisdiction(fdr);
 
         // if they're outside sector, currently tracked, and not going to re-enter, drop them
         if (!isInControlledSector && fdr.IsTrackedByMe && !await WillEnter(fdr)) MMI.HandoffToNone(fdr);

--- a/State/JurisdictionManager.cs
+++ b/State/JurisdictionManager.cs
@@ -13,15 +13,16 @@ public static class JurisdictionManager
 
         var isInControlledSector = await IsInControlledSector(fdr.GetLocation(), fdr.PRL);
         var atopState = fdr.GetAtopState();
-        var activated = AtopPluginStateManager.IsActivated();
 
         // check if aircraft previously tracked to avoid re-tracking manually dropped/handed off tracks
-        if (activated && isInControlledSector && !fdr.IsTracked && atopState is { WasHandedOff: false })
+        if (AtopPluginStateManager.Activated && isInControlledSector && !fdr.IsTracked &&
+            atopState is { WasHandedOff: false })
             MMI.AcceptJurisdiction(fdr);
 
         // if they're outside sector, currently tracked, and not going to re-enter, drop them
         // also drop them if we are not activated
-        if ((!isInControlledSector && fdr.IsTrackedByMe && !await WillEnter(fdr)) || (fdr.IsTrackedByMe && !activated))
+        if ((!isInControlledSector && fdr.IsTrackedByMe && !await WillEnter(fdr)) ||
+            (fdr.IsTrackedByMe && !AtopPluginStateManager.Activated))
             MMI.HandoffToNone(fdr);
     }
 

--- a/UI/AtopMenu.cs
+++ b/UI/AtopMenu.cs
@@ -1,0 +1,50 @@
+using System.Windows.Forms;
+using AtopPlugin.State;
+using vatsys;
+using vatsys.Plugin;
+
+namespace AtopPlugin.UI;
+
+public static class AtopMenu
+{
+    private const string CategoryName = "ATOP";
+
+    private static readonly SettingsWindow SettingsWindow = new();
+    private static readonly ToolStripMenuItem ActivationToggle = new("Activate");
+
+    static AtopMenu()
+    {
+        InitializeSettingsMenu();
+        InitializeActivationToggle();
+    }
+    
+    // empty method to force static class initialization to happen
+    public static void Initialize() {}
+
+    private static void InitializeSettingsMenu()
+    {
+        var settingsMenuItem = new CustomToolStripMenuItem(CustomToolStripMenuItemWindowType.Main,
+            CustomToolStripMenuItemCategory.Custom, new ToolStripMenuItem("Settings"))
+        {
+            CustomCategoryName = CategoryName
+        };
+        settingsMenuItem.Item.Click += (_, _) => MMI.InvokeOnGUI(SettingsWindow.Show);
+        MMI.AddCustomMenuItem(settingsMenuItem);
+    }
+
+    private static void InitializeActivationToggle()
+    {
+        var activationMenuItem = new CustomToolStripMenuItem(CustomToolStripMenuItemWindowType.Main,
+            CustomToolStripMenuItemCategory.Custom, ActivationToggle)
+        {
+            CustomCategoryName = CategoryName
+        };
+        activationMenuItem.Item.Click += (_, _) => MMI.InvokeOnGUI(AtopPluginStateManager.ToggleActivated);
+        MMI.AddCustomMenuItem(activationMenuItem);
+    }
+
+    public static void SetActivationState(bool state)
+    {
+        ActivationToggle.Checked = state;
+    }
+}


### PR DESCRIPTION
- Improve logic for ensuring handed off aircraft are not re-assumed
- Add "activation" functionality which stops any aircraft from being assumed immediately
  - This allows for better interactions when there are two controllers online with the same sectors selected - it allows one controller to be "unactivated" if they are just watching the other